### PR TITLE
chore(dependabot): Receive updates from Coop's private go registry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,14 @@
 ---
 version: 2
 
+registries:
+  github-coopnorge:
+    type: git
+    url: https://github.com
+    username: x-access-token
+    password: ${{secrets.DEPENDABOT_GHCR_PULL}}
+
+
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Aims to make dependabot send updates from Coop's private go dependencies.

- Ensures that a dependabot config file exists
- Ensures that YAML values are properly quoted
- Ensures that every directory with a gomod file has a corresponding dependabot config
- Ensures that a global `registries` key exists
- Ensures that a `github-coopnorge` registry exists
- Ensures that every gomod package-ecosystem entry has the `github-coopnorge` registry specified

This PR has been created by a [codemod you can find here](https://github.com/coopnorge/codemod/tree/main/2023-10-add-private-gomod-registry). Although we try to make things painless, the changes might require human oversight. Feel free to edit this PR, to merge or to close it.

There is one known issue:
If all of these are true, you will need to do manual changes to the dependabot config file:
  - There is only one gomod file in the repository
  - This gomod file does not already have a dependabot config
  - There exists a dependabot config for another ecosystem in the same directory

The typical fix would be to add an ecosystem config for your gomod ecosystem.

See https://github.com/coopnorge/codemod/pull/9
See https://github.com/coopnorge/engineering-issues/issues/328