### PR TITLE
ci(dependabot): Add gomod ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,13 @@ registries:
     username: x-access-token
     password: ${{secrets.DEPENDABOT_GHCR_PULL}}
 
-
 updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    registries:
+      - github-coopnorge
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Fixes the missing gomod ecosystem from #8. This is the single listed known issue mentioned in #8 