### PR TITLE
118996 handle mutex on context cancel

### DIFF
--- a/creational/pool/pool.go
+++ b/creational/pool/pool.go
@@ -96,6 +96,10 @@ func NewResourcePoolManager[T Resource](poolSize, resourceUsageLimit uint8, reso
 // ResourcePoolManager will try to obtain Resource when it will be available recursively until context.Context will be canceled.
 // If there is no need to re-try, pass `isNeedToRetryOnTaken` as false.
 func (rpm *ResourcePoolManager[T]) AcquireResource(ctx context.Context, isNeedToRetryOnTaken bool) (*T, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
 	obtainedResource := make(chan resourceObtainer[T], 1)
 	go rpm.getResource(obtainedResource)
 

--- a/creational/pool/pool_test.go
+++ b/creational/pool/pool_test.go
@@ -214,9 +214,9 @@ func TestReleaseResourceWithCanceledContext(t *testing.T) {
 	assert.NoError(t, firstResErr)
 	assert.NotNil(t, firstRes)
 
-	unitContextCancel()
-
 	manager.ReleaseResource(firstRes)
+
+	unitContextCancel()
 
 	canceledRes, canceledResErr := manager.AcquireResource(unitContext, false)
 	assert.NotNil(t, canceledResErr)


### PR DESCRIPTION
Handle case when during `AcquireResource` after calling `getResource` context could be canceled but mutex was locking, in result that was leading to panic error