### PR TITLE
Fix package name string that was colliding with reserved type in go

### DIFF
--- a/docs/strconv/number.md
+++ b/docs/strconv/number.md
@@ -14,12 +14,12 @@ package main
 import (
   "fmt"
 
-  "github.com/coopnorge/member-lib/strconvex"
+  "github.com/coopnorge/member-lib/strconv"
 )
 
 func main() {
   given := "-32767"
-  parsed, parserErr := string.ToWholeNumber[int8](given)
+  parsed, parserErr := strconv.ToWholeNumber[int8](given)
   if parserErr != nil {
     // TODO Deal with that
   } else {

--- a/strconv/number.go
+++ b/strconv/number.go
@@ -1,4 +1,4 @@
-package strconvex
+package strconv
 
 import (
 	"fmt"

--- a/strconv/number_test.go
+++ b/strconv/number_test.go
@@ -1,4 +1,4 @@
-package strconvex
+package strconv
 
 import (
 	"reflect"


### PR DESCRIPTION
Fix package name of `string` to `strconvex` - a combination (string conversion, reminiscent of the standard library package)