### PR TITLE
Rename strconv to stringconv

### DIFF
--- a/docs/stringconv/number.md
+++ b/docs/stringconv/number.md
@@ -14,12 +14,12 @@ package main
 import (
   "fmt"
 
-  "github.com/coopnorge/member-lib/strconv"
+  "github.com/coopnorge/member-lib/stringconv"
 )
 
 func main() {
   given := "-32767"
-  parsed, parserErr := strconv.ToWholeNumber[int8](given)
+  parsed, parserErr := stringconv.ToWholeNumber[int8](given)
   if parserErr != nil {
     // TODO Deal with that
   } else {

--- a/stringconv/number.go
+++ b/stringconv/number.go
@@ -1,4 +1,4 @@
-package strconv
+package stringconv
 
 import (
 	"fmt"

--- a/stringconv/number_test.go
+++ b/stringconv/number_test.go
@@ -1,4 +1,4 @@
-package strconv
+package stringconv
 
 import (
 	"reflect"


### PR DESCRIPTION
Use more unique name so it will not collide, only 4 packages now exist with that name -> https://pkg.go.dev/search?q=stringconv