### PR TITLE
Fix unused metdata in logs after merging from context

### DIFF
--- a/tracelogix/contextuallogger/logger.go
+++ b/tracelogix/contextuallogger/logger.go
@@ -88,5 +88,5 @@ func (tl *TraceLog) Log(sourceCtx context.Context, logSeverity LogAdapterLevel, 
 		maps.Copy(logFieldsToLog, metadata)
 	}
 
-	tl.logAdapter.LogAdaptersWriter(sourceCtx, logSeverity, logMessage, logMeta)
+	tl.logAdapter.LogAdaptersWriter(sourceCtx, logSeverity, logMessage, &logFieldsToLog)
 }


### PR DESCRIPTION
Fix map usage of metadata for log adpater