### PR TITLE
Distinguish extractor parsing error from bad request response in OpenAPI

### DIFF
--- a/net/openapi/response.go
+++ b/net/openapi/response.go
@@ -14,7 +14,7 @@ type Response struct {
 
 // ExtractErrorResponse extracts error details from Response if the HTTP status code indicates an error.
 // It returns a map of the error details if an error is present, otherwise nil.
-func ExtractErrorResponse(resp *Response) (errResponse map[string]any, extractErr error) {
+func ExtractErrorResponse(resp *Response) (errResponse map[string]any, parsingErr error) {
 	if resp == nil {
 		return nil, fmt.Errorf("http error: response not exist")
 	}
@@ -28,32 +28,36 @@ func ExtractErrorResponse(resp *Response) (errResponse map[string]any, extractEr
 		if err := json.Unmarshal(*resp.HTTPResponseBody, &errResponse); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal successful response: %w", err)
 		}
+
+		return errResponse, nil
 	}
 
-	extractErr = fmt.Errorf(
-		"http response contains not successful response status (%d - %s) no payload details",
-		resp.HTTPResponse.StatusCode,
-		http.StatusText(resp.HTTPResponse.StatusCode),
-	)
+	errResponse = map[string]any{
+		"HTTPStatusCode": resp.HTTPResponse.StatusCode,
+		"HTTPStatusText": http.StatusText(resp.HTTPResponse.StatusCode),
+	}
 
 	return
 }
 
 // ExtractResponse extracts the JSON payload from an Response into T if the HTTP status is successful or empty in cases like HTTP 204 No content.
 // Any error response placed as map, or an error if the extraction fails.
-func ExtractResponse[T any](resp *Response) (successResponse *T, errorResponse map[string]any, extractErr error) {
-	errorResponse, extractErr = ExtractErrorResponse(resp)
-	if extractErr != nil {
-		return nil, errorResponse, extractErr
+func ExtractResponse[T any](resp *Response) (expectedResponse *T, badRequestResponse map[string]any, parsingErr error) {
+	badRequestResponse, parsingErr = ExtractErrorResponse(resp)
+	if parsingErr != nil {
+		return nil, nil, parsingErr
+	}
+	if badRequestResponse != nil {
+		return nil, badRequestResponse, nil
 	}
 
 	if resp.HTTPResponseBody == nil {
 		return
 	}
 
-	if err := json.Unmarshal(*resp.HTTPResponseBody, &successResponse); err != nil {
+	if err := json.Unmarshal(*resp.HTTPResponseBody, &expectedResponse); err != nil {
 		return nil, nil, fmt.Errorf("failed to unmarshal successful response: %w", err)
 	}
 
-	return successResponse, nil, nil
+	return expectedResponse, nil, nil
 }


### PR DESCRIPTION
Distinguish extractor parsing error from bad request response that was provided by client