### PR TITLE
Allow Release Drafter run only for main branch

### DIFF
--- a/.github/workflows/draft-release.yaml
+++ b/.github/workflows/draft-release.yaml
@@ -3,12 +3,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - edited
 permissions:
   contents: read
 


### PR DESCRIPTION
Allow run workflow for branch main not for PRs or another branches.