### PR TITLE
Add support for default tag in the config loader

### DIFF
--- a/configloader/configloader.go
+++ b/configloader/configloader.go
@@ -11,7 +11,7 @@ import (
 )
 
 type Loader struct {
-	prefix, tag string
+	prefix, nameTag string
 
 	// Type of conversion the struct field will take. Default is SnakeCase.
 	fieldConversion func(string) string
@@ -49,7 +49,7 @@ func WithTypeHandler[T any](f func(string) (T, error)) Option {
 // WithNameTag sets the prefix for environment variable names.
 func WithNameTag(tag string) Option {
 	return func(l *Loader) {
-		l.tag = tag
+		l.nameTag = tag
 	}
 }
 
@@ -113,7 +113,7 @@ func (l *Loader) loadFields(v reflect.Value, t reflect.Type, prefix string) erro
 		convertedFName := l.fieldConversion(fieldType.Name)
 
 		var found bool
-		envName := fieldType.Tag.Get(l.tag)
+		envName := fieldType.Tag.Get(l.nameTag)
 		if envName == "" {
 			found = false
 			envName = convertedFName

--- a/configloader/configloader.go
+++ b/configloader/configloader.go
@@ -1,17 +1,18 @@
 package configloader
 
 import (
+	"errors"
 	"fmt"
+	"iter"
 	"os"
 	"reflect"
-	"strconv"
 	"strings"
 
 	"github.com/iancoleman/strcase"
 )
 
 type Loader struct {
-	prefix, nameTag, defaultTag string
+	prefix, nameTag, envTag, defaultTag string
 
 	// Type of conversion the struct field will take. Default is SnakeCase.
 	fieldConversion func(string) string
@@ -23,12 +24,34 @@ type Loader struct {
 	handlers map[reflect.Type]func(string) (any, error)
 }
 
+type Field struct {
+	Value reflect.Value
+	Path  []reflect.StructField
+}
+
+func (f *Field) Last() reflect.StructField {
+	return f.Path[len(f.Path)-1]
+}
+
+func (f *Field) Names() (names []string) {
+	for _, field := range f.Path {
+		names = append(names, field.Name)
+	}
+	return names
+}
+
+func (f *Field) String() string {
+	return fmt.Sprintf("%s (%s)", strings.Join(f.Names(), "."), f.Value.Type().String())
+}
+
 func defaultLoader() *Loader {
 	l := &Loader{
 		handlers:        make(map[reflect.Type]func(string) (any, error), 0),
 		fieldConversion: strcase.ToScreamingSnake,
-		env:             os.LookupEnv,
-		defaultTag:      "default",
+		env: func(val string) (string, bool) {
+			return os.LookupEnv(strings.ToUpper(val))
+		},
+		defaultTag: "default",
 	}
 	for _, opt := range defaultTypeHandlers {
 		opt(l)
@@ -36,221 +59,270 @@ func defaultLoader() *Loader {
 	return l
 }
 
-type Option func(*Loader)
-
-func WithTypeHandler[T any](f func(string) (T, error)) Option {
-	return func(l *Loader) {
-		var zero T
-		l.handlers[reflect.TypeOf(zero)] = func(value string) (any, error) {
-			return f(value)
-		}
-	}
-}
-
-// WithNameTag sets the tag used to override environment variable names.
-func WithNameTag(tag string) Option {
-	return func(l *Loader) {
-		l.nameTag = tag
-	}
-}
-
-// WithDefaultTag sets the tag to use for default values.
-func WithDefaultTag(tag string) Option {
-	return func(l *Loader) {
-		l.defaultTag = tag
-	}
-}
-
-// WithPrefix sets the prefix for environment variable names.
-func WithPrefix(prefix string) Option {
-	return func(l *Loader) {
-		l.prefix = prefix
-	}
-}
-
-// WithEnv sets a custom environment variable lookup function.
-func WithEnv(env func(string) (string, bool)) Option {
-	return func(l *Loader) {
-		l.env = env
-	}
-}
-
+// Load populates a struct's fields with values from environment variables.
+// It takes a pointer to a struct and optional configuration options.
+//
+// Each struct field's name is converted to SCREAMING_SNAKE_CASE to determine the
+// environment variable name. For example:
+//   - Field "ServerPort" looks for "SERVER_PORT"
+//   - Field "DatabaseURL" looks for "DATABASE_URL"
+//   - Nested field "Database.Password" looks for "DATABASE_PASSWORD"
+//
+// Supported field types out of the box:
+//   - Basic types: string, bool, int*, uint*, float*
+//   - time.Duration, time.Time (RFC3339 format)
+//   - net.IP, *net.IPNet (CIDR)
+//   - *url.URL, *regexp.Regexp
+//   - json.RawMessage
+//   - []byte (base64 encoded)
+//   - Slices of any supported type (comma-separated values)
+//
+// Features:
+//   - Custom type support via WithTypeHandler
+//   - Default values via struct tags: `default:"value"`
+//   - Custom env names via struct tags: `env:"CUSTOM_NAME"`
+//   - Optional prefix for all env vars: WithPrefix("APP")
+//   - Nested struct support
+//   - Pointer fields are automatically initialized
+//
+// Example usage:
+//
+//	type Config struct {
+//	    Port        int           `default:"8080"`
+//	    Host        string        `env:"SERVICE_HOST"`
+//	    Timeout     time.Duration
+//	    Database struct {
+//	        URL      string
+//	        Password string
+//	    }
+//	}
+//
+//	var cfg Config
+//	err := configloader.Load(&cfg,
+//	    WithPrefix("APP"),
+//	    WithNameTag("env"),
+//	    WithDefaultTag("default"),
+//	)
+//
+// The above will look for these environment variables:
+//   - APP_PORT (default: "8080")
+//   - SERVICE_HOST (custom name via tag)
+//   - APP_TIMEOUT
+//   - APP_DATABASE_URL
+//   - APP_DATABASE_PASSWORD
+//
+// Returns an error if:
+//   - The value is not a pointer to a struct
+//   - Required environment variables are missing
+//   - Type conversion fails for any field
+//   - Any field has an unsupported type
 func Load(value any, opts ...Option) error {
 	loader := defaultLoader()
 	for _, opt := range opts {
 		opt(loader)
 	}
-
 	return loader.Load(value)
 }
 
-// Load loads a configuration struct from environment variables.
-// It supports nested structs and handles type conversion for basic types.
 func (l *Loader) Load(val any) error {
 	ptrValue := reflect.ValueOf(val)
-	if ptrValue.Kind() != reflect.Pointer || ptrValue.IsNil() {
-		return fmt.Errorf("need a pointer to load values into. Got %s", reflect.TypeOf(val).String())
+	if ptrValue.Kind() != reflect.Pointer {
+		return fmt.Errorf("val must be a pointer, got '%s'", reflect.TypeOf(val).String())
 	}
-	v := ptrValue.Elem()
-	t := ptrValue.Type().Elem()
+	if ptrValue.IsNil() {
+		return fmt.Errorf("val cannot be nil")
+	}
 
-	if err := l.loadFields(v, t, l.prefix); err != nil {
-		return fmt.Errorf("failed to load configuration: %w", err)
+	errs := ConfigLoadError{
+		Value: ptrValue.Elem().Type(),
+	}
+
+	// Iterate over each leaf variables of the struct.
+	for variable := range traverse(Field{Value: ptrValue}, l.getChildren) {
+		err := l.parse(variable)
+		if err != nil {
+			errs.Add(FieldError{
+				Field: variable,
+				Err:   err,
+			})
+		}
+	}
+	if len(errs.Errors) > 0 {
+		return &errs
 	}
 	return nil
 }
 
-// loadFields recursively processes struct fields and loads values from environment variables.
-// nolint:gocognit // Necessary complexity. High IQ function.
-func (l *Loader) loadFields(v reflect.Value, t reflect.Type, prefix string) error {
-	if !v.IsValid() {
-		return fmt.Errorf("struct should be an initialized pointer")
+func (l *Loader) parse(variable Field) error {
+	name, err := l.keyName(variable)
+	if err != nil {
+		return err
+	}
+	value, err := l.lookup(name, variable)
+	if err != nil {
+		return err
+	}
+	err = l.set(value, variable)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (l *Loader) keyName(variable Field) (string, error) {
+	var names []string
+	if l.prefix != "" {
+		names = append(names, l.prefix)
 	}
 
-	for i := 0; i < t.NumField(); i++ {
-		field := v.Field(i)
-		fieldType := t.Field(i)
-
-		if !field.CanSet() || !field.IsValid() {
-			continue
+	// Env not last.
+	var fieldsWithEnv []reflect.StructField
+	for _, field := range variable.Path[:len(variable.Path)-1] {
+		if _, found := field.Tag.Lookup(l.envTag); found {
+			fieldsWithEnv = append(fieldsWithEnv, field)
 		}
-		newPrefix := prefix
-		if newPrefix != "" {
-			newPrefix += "_"
-		}
-		convertedFName := l.fieldConversion(fieldType.Name)
+	}
+	if len(fieldsWithEnv) > 0 {
+		return "", fmt.Errorf("´%s´ tag need to be at the end: %v", l.envTag, fieldsWithEnv)
+	}
 
-		var found bool
-		envName := fieldType.Tag.Get(l.nameTag)
-		if envName == "" {
-			found = false
-			envName = convertedFName
+	if name, found := variable.Last().Tag.Lookup(l.envTag); found {
+		return name, nil
+	}
+
+	for _, field := range variable.Path {
+		if value, found := field.Tag.Lookup(l.nameTag); found {
+			names = append(names, value)
 		} else {
-			envName = strings.Split(envName, ",")[0]
-			if prefix != "" && !strings.Contains(envName, newPrefix) {
-				envName = newPrefix + envName
-			}
-			found = true
+			names = append(names, l.fieldConversion(field.Name))
 		}
+	}
+	key := strings.Join(names, "_")
+	return key, nil
+}
 
-		if prefix != "" && !found {
-			envName = newPrefix + envName
-		}
-
-		// At times, an explicit loading can be added, so we can route here
-		_, ok := l.handlers[fieldType.Type]
-		if ok {
-			if err := l.setFieldValue(field, l.getOrDefault(&fieldType, envName)); err != nil {
-				return fmt.Errorf("error setting field %s: %w", fieldType.Name, err)
+func (l *Loader) handler(typ reflect.Type) (func(reflect.Value, string) error, error) {
+	_, ok := l.handlers[typ]
+	if ok {
+		return func(value reflect.Value, val string) error {
+			v, err := l.handlers[typ](val)
+			if err == nil {
+				value.Set(reflect.ValueOf(v))
 			}
-			continue
-		}
-
-		// Handle pointers to structs
-		if field.Kind() == reflect.Ptr {
-			ptrType := field.Type().Elem()
-			// Initialize if nil
-			if field.IsNil() {
-				field.Set(reflect.New(ptrType))
-			}
-			// If it's a pointer to struct, process it
-			if field.Elem().Kind() == reflect.Struct {
-				newPrefix += convertedFName
-				if err := l.loadFields(field.Elem(), ptrType, newPrefix); err != nil {
-					return fmt.Errorf("error loading nested pointer struct %s: %w", fieldType.Name, err)
+			return err
+		}, nil
+	}
+	if typ.Kind() == reflect.Slice {
+		eh, err := l.handler(typ.Elem())
+		if err == nil {
+			return func(value reflect.Value, val string) (err error) {
+				elements := strings.Split(val, ",")
+				slice := reflect.MakeSlice(value.Type(), len(elements), len(elements))
+				for i, element := range elements {
+					herr := eh(slice.Index(i), element)
+					if herr != nil {
+						err = errors.Join(err, herr)
+					}
 				}
+				value.Set(slice)
+				return err
+			}, nil
+		}
+	}
+	return nil, &UnsupportedTypeError{typ}
+}
+
+func (l *Loader) canHandle(field reflect.Value) bool {
+	if !field.CanSet() || !field.IsValid() {
+		return false
+	}
+	_, err := l.handler(field.Type())
+	return err == nil
+}
+
+// traverse yields the leaf nodes of a tree.
+func traverse[T any](root T, childFn func(T) []T) iter.Seq[T] {
+	return func(yield func(T) bool) {
+		var traverse func(T) bool
+		traverse = func(node T) bool {
+			children := childFn(node)
+			if len(children) == 0 {
+				return yield(node)
+			}
+			for _, child := range children {
+				if !traverse(child) {
+					return false
+				}
+			}
+			return true
+		}
+		traverse(root)
+	}
+}
+
+func (l *Loader) getChildren(current Field) []Field {
+	if l.canHandle(current.Value) {
+		return nil
+	}
+
+	// Unwrap the current if it's a pointer.
+	if current.Value.Kind() == reflect.Ptr {
+		if current.Value.IsNil() {
+			current.Value.Set(reflect.New(current.Value.Type().Elem()))
+		}
+		return []Field{{
+			Value: current.Value.Elem(),
+			Path:  current.Path,
+		}}
+	}
+
+	if current.Value.Kind() == reflect.Struct {
+		var children []Field
+		for i := 0; i < current.Value.NumField(); i++ {
+			fv := current.Value.Field(i)
+			ft := current.Value.Type().Field(i)
+
+			if !fv.CanSet() || !fv.IsValid() {
 				continue
 			}
-		}
-
-		if field.Kind() == reflect.Struct {
-			newPrefix += convertedFName
-			if err := l.loadFields(field, fieldType.Type, newPrefix); err != nil {
-				return fmt.Errorf("error loading nested struct %s: %w", fieldType.Name, err)
+			if ft.Anonymous {
+				children = append(children, Field{
+					Value: fv,
+					Path:  current.Path,
+				})
+			} else {
+				children = append(children, Field{
+					Value: fv,
+					Path:  append(current.Path, ft),
+				})
 			}
-			continue
 		}
-
-		if err := l.setFieldValue(field, l.getOrDefault(&fieldType, envName)); err != nil {
-			return fmt.Errorf("error setting field %s: %w", fieldType.Name, err)
-		}
+		return children
 	}
 	return nil
 }
 
-func (l *Loader) getOrDefault(fieldType *reflect.StructField, envName string) string {
-	value, found := l.env(envName)
-	if found && value != "" {
-		return value
-	}
-
-	if value, found = fieldType.Tag.Lookup(l.defaultTag); found {
-		return value
-	}
-	// TODO: Error.
-	return value
-}
-
-// setFieldValue converts string value from environment variable to appropriate field type.
-// nolint:funlen // Switch statement makes this a lengthy func.
-func (l *Loader) setFieldValue(field reflect.Value, value string) error {
-	// skip if value is nil or empty
-	if value == "" {
-		return nil
-	}
-
-	// Override type if a specific handler was given.
-	// NOTE: Overrides of Complex Types masks could be picked up instead of the masked type.
-	f, ok := l.handlers[field.Type()]
-	if ok {
-		v, err := f(value)
-		if err != nil {
-			return err
-		}
-		field.Set(reflect.ValueOf(v))
-		return nil
-	}
-
-	switch field.Kind() {
-	case reflect.String:
-		field.SetString(value)
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		val, err := strconv.ParseInt(value, 10, 64)
-		if err != nil {
-			return err
-		}
-		field.SetInt(val)
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		val, err := strconv.ParseUint(value, 10, 64)
-		if err != nil {
-			return err
-		}
-		field.SetUint(val)
-	case reflect.Float32, reflect.Float64:
-		val, err := strconv.ParseFloat(value, 64)
-		if err != nil {
-			return err
-		}
-		field.SetFloat(val)
-	case reflect.Bool:
-		val, err := strconv.ParseBool(value)
-		if err != nil {
-			// Let user know that Parsing is wrong
-			return err
-		}
-		field.SetBool(val)
-	case reflect.Slice:
-		// Handle slice types (split by comma)
-		elements := strings.Split(value, ",")
-		slice := reflect.MakeSlice(field.Type(), len(elements), len(elements))
-		for i, element := range elements {
-			if err := l.setFieldValue(slice.Index(i), strings.TrimSpace(element)); err != nil {
-				return err
+func (l *Loader) lookup(key string, variable Field) (string, error) {
+	field := variable.Path[len(variable.Path)-1]
+	value, found := l.env(key)
+	if !found || value == "" {
+		if value, found = field.Tag.Lookup(l.defaultTag); !found {
+			return "", MissingEnvError{
+				Key: key,
 			}
 		}
-		field.Set(slice)
-	default:
-		return fmt.Errorf("unsupported field type: %s", field.Kind())
+	}
+	return value, nil
+}
+
+func (l *Loader) set(value string, variable Field) error {
+	handler, err := l.handler(variable.Value.Type())
+	if err != nil {
+		return err
+	}
+	err = handler(variable.Value, value)
+	if err != nil {
+		return err
 	}
 	return nil
 }

--- a/configloader/configloader.go
+++ b/configloader/configloader.go
@@ -54,7 +54,7 @@ func WithNameTag(tag string) Option {
 	}
 }
 
-// WithDefaultTag sets the tag to use for default values
+// WithDefaultTag sets the tag to use for default values.
 func WithDefaultTag(tag string) Option {
 	return func(l *Loader) {
 		l.defaultTag = tag
@@ -140,7 +140,7 @@ func (l *Loader) loadFields(v reflect.Value, t reflect.Type, prefix string) erro
 		// At times, an explicit loading can be added, so we can route here
 		_, ok := l.handlers[fieldType.Type]
 		if ok {
-			if err := l.setFieldValue(field, l.getOrDefault(fieldType, envName)); err != nil {
+			if err := l.setFieldValue(field, l.getOrDefault(&fieldType, envName)); err != nil {
 				return fmt.Errorf("error setting field %s: %w", fieldType.Name, err)
 			}
 			continue
@@ -171,14 +171,14 @@ func (l *Loader) loadFields(v reflect.Value, t reflect.Type, prefix string) erro
 			continue
 		}
 
-		if err := l.setFieldValue(field, l.getOrDefault(fieldType, envName)); err != nil {
+		if err := l.setFieldValue(field, l.getOrDefault(&fieldType, envName)); err != nil {
 			return fmt.Errorf("error setting field %s: %w", fieldType.Name, err)
 		}
 	}
 	return nil
 }
 
-func (l *Loader) getOrDefault(fieldType reflect.StructField, envName string) string {
+func (l *Loader) getOrDefault(fieldType *reflect.StructField, envName string) string {
 	value, found := l.env(envName)
 	if found && value != "" {
 		return value

--- a/configloader/configloader.go
+++ b/configloader/configloader.go
@@ -28,6 +28,7 @@ func defaultLoader() *Loader {
 		handlers:        make(map[reflect.Type]func(string) (any, error), 0),
 		fieldConversion: strcase.ToScreamingSnake,
 		env:             os.LookupEnv,
+		defaultTag:      "default",
 	}
 	for _, opt := range defaultTypeHandlers {
 		opt(l)

--- a/configloader/configloader.go
+++ b/configloader/configloader.go
@@ -11,7 +11,7 @@ import (
 )
 
 type Loader struct {
-	prefix, nameTag string
+	prefix, nameTag, defaultTag string
 
 	// Type of conversion the struct field will take. Default is SnakeCase.
 	fieldConversion func(string) string
@@ -46,10 +46,17 @@ func WithTypeHandler[T any](f func(string) (T, error)) Option {
 	}
 }
 
-// WithNameTag sets the prefix for environment variable names.
+// WithNameTag sets the tag used to override environment variable names.
 func WithNameTag(tag string) Option {
 	return func(l *Loader) {
 		l.nameTag = tag
+	}
+}
+
+// WithDefaultTag sets the tag to use for default values
+func WithDefaultTag(tag string) Option {
+	return func(l *Loader) {
+		l.defaultTag = tag
 	}
 }
 

--- a/configloader/configloader_test.go
+++ b/configloader/configloader_test.go
@@ -176,6 +176,7 @@ func TestWithPrefixTag(t *testing.T) {
 }
 
 func TestWithDefaultTag(t *testing.T) {
+
 	t.Run("uses value from default", func(t *testing.T) {
 		var cfg struct {
 			Foo string `default:"foo"`
@@ -184,13 +185,29 @@ func TestWithDefaultTag(t *testing.T) {
 			}
 		}
 
-		err := Load(&cfg, WithDefaultTag("default"), WithEnv(CustomGetenv))
+		err := Load(&cfg, WithEnv(CustomGetenv))
+		assert.NoError(t, err)
+		assert.Equal(t, "foo", cfg.Foo)
+		assert.Equal(t, "baz", cfg.Bar.Baz)
+	})
+
+	t.Run("uses custom tag", func(t *testing.T) {
+		var cfg struct {
+			Foo string `default2:"foo"`
+			Bar struct {
+				Baz string `default2:"baz"`
+			}
+		}
+
+		err := Load(&cfg, WithDefaultTag("default2"), WithEnv(CustomGetenv))
 		assert.NoError(t, err)
 		assert.Equal(t, "foo", cfg.Foo)
 		assert.Equal(t, "baz", cfg.Bar.Baz)
 	})
 
 	t.Run("uses value from env", func(t *testing.T) {
+		defer os.Clearenv()
+
 		var cfg struct {
 			Foo string `default:"foo"`
 			Bar struct {
@@ -201,7 +218,7 @@ func TestWithDefaultTag(t *testing.T) {
 		require.NoError(t, os.Setenv("FOO", "fooEnv"))
 		require.NoError(t, os.Setenv("BAR_BAZ", "bazEnv"))
 
-		err := Load(&cfg, WithDefaultTag("default"), WithEnv(CustomGetenv))
+		err := Load(&cfg, WithEnv(CustomGetenv))
 		assert.NoError(t, err)
 		assert.Equal(t, "fooEnv", cfg.Foo)
 		assert.Equal(t, "bazEnv", cfg.Bar.Baz)
@@ -215,7 +232,7 @@ func TestWithDefaultTag(t *testing.T) {
 			}
 		}
 
-		err := Load(&cfg, WithDefaultTag("default"), WithEnv(CustomGetenv))
+		err := Load(&cfg, WithEnv(CustomGetenv))
 		assert.NoError(t, err)
 
 		foo, err := url.Parse("https://example.com/foo")

--- a/configloader/configloader_test.go
+++ b/configloader/configloader_test.go
@@ -77,7 +77,7 @@ func TestLoad(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			os.Clearenv()
 			for k, v := range tt.envVars {
-				os.Setenv(k, v)
+				require.NoError(t, os.Setenv(k, v))
 			}
 
 			got := &AppConfig{}
@@ -157,6 +157,24 @@ func TestComplexLoading(t *testing.T) {
 	assert.Equal(t, "hehe://someproto", conf.DSD, "Dsd was not picked up ")
 }
 
+func TestWithPrefixTag(t *testing.T) {
+	var cfg struct {
+		Foo string
+		Bar struct {
+			Baz string
+		}
+	}
+
+	require.NoError(t, os.Setenv("TEST_FOO", "fooEnv"))
+	require.NoError(t, os.Setenv("TEST_BAR_BAZ", "bazEnv"))
+
+	err := Load(&cfg, WithPrefix("TEST"), WithEnv(CustomGetenv))
+	assert.NoError(t, err)
+	assert.Equal(t, "fooEnv", cfg.Foo)
+	assert.Equal(t, "bazEnv", cfg.Bar.Baz)
+
+}
+
 func TestWithDefaultTag(t *testing.T) {
 	t.Run("uses value from default", func(t *testing.T) {
 		var cfg struct {
@@ -181,7 +199,7 @@ func TestWithDefaultTag(t *testing.T) {
 		}
 
 		require.NoError(t, os.Setenv("FOO", "fooEnv"))
-		require.NoError(t, os.Setenv("FOO", "bazEnv"))
+		require.NoError(t, os.Setenv("BAZ", "bazEnv"))
 
 		err := Load(&cfg, WithDefaultTag("default"), WithEnv(CustomGetenv))
 		assert.NoError(t, err)

--- a/configloader/configloader_test.go
+++ b/configloader/configloader_test.go
@@ -129,7 +129,7 @@ func TestNameJson(t *testing.T) {
 type ComplexConfig struct {
 	Env     string `mapstructure:"dd_env" json:"dd_env,omitempty"`
 	Service string `mapstructure:"dd_service" json:"dd_service,omitempty"`
-	// Field Name is not the same as mapstructure tag val
+	// Field Name is not the same as mapstructure nameTag val
 	ServiceVersion       string `mapstructure:"dd_version" json:"dd_service_version,omitempty"`
 	DSD                  string `mapstructure:"dd_dogstatsd_url" json:"dd_dsd,omitempty"`
 	APM                  string `mapstructure:"dd_trace_agent_url" json:"dd_apm,omitempty"`

--- a/configloader/configloader_test.go
+++ b/configloader/configloader_test.go
@@ -1,160 +1,124 @@
 package configloader
 
 import (
-	"net"
+	"errors"
 	"net/url"
 	"os"
-	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestLoad(t *testing.T) {
-	type DatabaseConfig struct {
-		Host     string
-		Port     int
-		Username string `env:"DATABASE_USER"`
-		Password string
-	}
-	type AppConfig struct {
-		Environment string
-		Debug       bool
-		Database    DatabaseConfig
-		AllowedIps  []string
-		MaxRetries  int
-		Timeout     float64
-	}
+func TestLoader_Load(t *testing.T) {
+	t.Run("support fields", func(t *testing.T) {
+		var cfg struct {
+			Foo string
+		}
+		t.Setenv("FOO", "foo")
+		defer os.Clearenv()
 
-	tests := []struct {
-		name    string
-		envVars map[string]string
-		want    AppConfig
-		wantErr bool
-	}{
-		{
-			name: "basic configuration",
-			envVars: map[string]string{
-				"ENVIRONMENT":       "production",
-				"DEBUG":             "true",
-				"DATABASE_HOST":     "localhost",
-				"DATABASE_PORT":     "5432",
-				"DATABASE_USER":     "admin",
-				"DATABASE_PASSWORD": "secret",
-				"ALLOWED_IPS":       "192.168.1.1,192.168.1.2",
-				"MAX_RETRIES":       "3",
-				"TIMEOUT":           "5.5",
-			},
-			want: AppConfig{
-				Environment: "production",
-				Debug:       true,
-				Database: DatabaseConfig{
-					Host:     "localhost",
-					Port:     5432,
-					Username: "admin",
-					Password: "secret",
-				},
-				AllowedIps: []string{"192.168.1.1", "192.168.1.2"},
-				MaxRetries: 3,
-				Timeout:    5.5,
-			},
-			wantErr: false,
-		},
-		{
-			name: "invalid type conversion",
-			envVars: map[string]string{
-				"ENVIRONMENT":   "production",
-				"DATABASE_PORT": "not_a_number",
-			},
-			want:    AppConfig{},
-			wantErr: true,
-		},
-	}
+		err := Load(&cfg)
+		require.NoError(t, err)
+		assert.Equal(t, "foo", cfg.Foo)
+	})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			os.Clearenv()
-			for k, v := range tt.envVars {
-				require.NoError(t, os.Setenv(k, v))
+	t.Run("support field pointers", func(t *testing.T) {
+		var cfg struct {
+			Foo *string
+		}
+		t.Setenv("FOO", "foo")
+		defer os.Clearenv()
+
+		err := Load(&cfg)
+		require.NoError(t, err)
+		assert.Equal(t, "foo", *cfg.Foo)
+	})
+
+	t.Run("support slices", func(t *testing.T) {
+		var cfg struct {
+			Foo []string
+		}
+		t.Setenv("FOO", "foo,bar")
+		defer os.Clearenv()
+
+		err := Load(&cfg)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"foo", "bar"}, cfg.Foo)
+	})
+
+	t.Run("support inner struct", func(t *testing.T) {
+		var cfg struct {
+			Inner struct {
+				Foo string
 			}
+		}
+		t.Setenv("INNER_FOO", "foo")
+		defer os.Clearenv()
 
-			got := &AppConfig{}
-			err := Load(got, WithNameTag("env"))
+		err := Load(&cfg)
+		require.NoError(t, err)
+		assert.Equal(t, "foo", cfg.Inner.Foo)
+	})
 
-			if tt.wantErr {
-				assert.Error(t, err)
-				return
+	t.Run("support inner struct pointers", func(t *testing.T) {
+		var cfg struct {
+			Inner *struct {
+				Foo string
 			}
+		}
+		t.Setenv("INNER_FOO", "foo")
+		defer os.Clearenv()
 
-			assert.NoError(t, err)
-			assert.Equal(t, tt.want.Environment, got.Environment)
-			assert.Equal(t, tt.want.Debug, got.Debug)
-			assert.Equal(t, tt.want.Database.Host, got.Database.Host)
-			assert.Equal(t, tt.want.Database.Port, got.Database.Port)
-			assert.Equal(t, tt.want.Database.Username, got.Database.Username)
-			assert.Equal(t, tt.want.Database.Password, got.Database.Password)
-			assert.Equal(t, tt.want.AllowedIps, got.AllowedIps)
-			assert.Equal(t, tt.want.MaxRetries, got.MaxRetries)
-			assert.Equal(t, tt.want.Timeout, got.Timeout)
-		})
-	}
-}
+		err := Load(&cfg)
+		require.NoError(t, err)
+		assert.Equal(t, "foo", cfg.Inner.Foo)
+	})
 
-func TestFails_OnConfigNotBeingStruct(t *testing.T) {
-	type AppConfig struct {
-		Name string
-	}
-	conf := AppConfig{}
-	assert.Error(t, Load(conf), "config should fail as it's not a pointer")
-}
+	t.Run("support embedded structs", func(t *testing.T) {
+		type Test struct {
+			Foo string
+		}
+		var cfg struct {
+			Test
+			Inner Test
+		}
+		t.Setenv("FOO", "foo")
+		t.Setenv("INNER_FOO", "foo")
+		defer os.Clearenv()
 
-func TestNameJson(t *testing.T) {
-	type JsonExm struct {
-		Name  string `json:"name"`
-		Split string `json:"split,omitempty"`
-	}
+		err := Load(&cfg)
+		require.NoError(t, err)
+		assert.Equal(t, "foo", cfg.Inner.Foo)
+		assert.Equal(t, "foo", cfg.Test.Foo)
+		assert.Equal(t, "foo", cfg.Foo)
+	})
 
-	t.Setenv("name", "hehe")
-	t.Setenv("split", "splitval")
+	t.Run("fails if not pointer", func(t *testing.T) {
+		var cfg struct {
+			Foo string
+		}
+		assert.EqualError(t, Load(cfg), "val must be a pointer, got 'struct { Foo string }'")
+	})
 
-	var conf JsonExm
+	t.Run("fails if nil pointer", func(t *testing.T) {
+		type Test struct {
+			Foo string
+		}
+		var cfg *Test
+		assert.EqualError(t, Load(cfg), "val cannot be nil")
+	})
 
-	err := Load(&conf, WithNameTag("json"))
-	assert.NoError(t, err, "Error should be nil")
-	assert.Equal(t, "hehe", conf.Name, "name is not the same as hehe")
-	assert.Equal(t, "splitval", conf.Split, "split is incorrenclty read")
-}
-
-type ComplexConfig struct {
-	Env     string `mapstructure:"dd_env" json:"dd_env,omitempty"`
-	Service string `mapstructure:"dd_service" json:"dd_service,omitempty"`
-	// Field Name is not the same as mapstructure nameTag val
-	ServiceVersion       string `mapstructure:"dd_version" json:"dd_service_version,omitempty"`
-	DSD                  string `mapstructure:"dd_dogstatsd_url" json:"dd_dsd,omitempty"`
-	APM                  string `mapstructure:"dd_trace_agent_url" json:"dd_apm,omitempty"`
-	EnableExtraProfiling bool   `mapstructure:"dd_enable_extra_profiling" json:"dd_enable_extra_profiling,omitempty"`
-}
-
-func CustomGetenv(val string) (string, bool) {
-	return os.LookupEnv(strings.ToUpper(val))
-}
-
-func TestComplexLoading(t *testing.T) {
-	t.Setenv("DD_ENV", "prod")
-	t.Setenv("DD_VERSION", "1.0.0")
-	t.Setenv("DD_DOGSTATSD_URL", "hehe://someproto")
-	t.Setenv("DD_ENABLE_EXTRA_PROFILING", "TRUE")
-
-	var conf ComplexConfig
-
-	err := Load(&conf, WithNameTag("mapstructure"), WithEnv(CustomGetenv))
-	assert.NoError(t, err, "Loading should not fail")
-	assert.Equal(t, "prod", conf.Env, "Env should be prod")
-	assert.Equal(t, "1.0.0", conf.ServiceVersion)
-	assert.Equal(t, "", conf.Service, "Service should be zero value")
-	assert.Equal(t, "hehe://someproto", conf.DSD, "Dsd was not picked up ")
+	t.Run("fails if environment not found", func(t *testing.T) {
+		type Test struct {
+			Foo string
+			Bar string
+		}
+		var cfg Test
+		assert.EqualError(t, Load(&cfg), `failed to load configloader.Test:
+error processing field Foo (string): environment variable FOO not found
+error processing field Bar (string): environment variable BAR not found`)
+	})
 }
 
 func TestWithPrefixTag(t *testing.T) {
@@ -165,18 +129,170 @@ func TestWithPrefixTag(t *testing.T) {
 		}
 	}
 
-	require.NoError(t, os.Setenv("TEST_FOO", "fooEnv"))
-	require.NoError(t, os.Setenv("TEST_BAR_BAZ", "bazEnv"))
+	t.Setenv("TEST_FOO", "fooEnv")
+	t.Setenv("TEST_BAR_BAZ", "bazEnv")
 
-	err := Load(&cfg, WithPrefix("TEST"), WithEnv(CustomGetenv))
+	err := Load(&cfg, WithPrefix("TEST"))
 	assert.NoError(t, err)
 	assert.Equal(t, "fooEnv", cfg.Foo)
 	assert.Equal(t, "bazEnv", cfg.Bar.Baz)
 
 }
 
-func TestWithDefaultTag(t *testing.T) {
+func TestWithPrefix(t *testing.T) {
+	t.Run("supports prefix", func(t *testing.T) {
+		var cfg struct {
+			Val    string
+			Struct struct {
+				Val string
+			}
+		}
+		t.Setenv("PREFIX_VAL", "bar")
+		t.Setenv("PREFIX_STRUCT_VAL", "bar")
+		err := Load(&cfg, WithPrefix("PREFIX"))
+		assert.NoError(t, err)
 
+		assert.Equal(t, "bar", cfg.Val)
+		assert.Equal(t, "bar", cfg.Struct.Val)
+	})
+}
+
+func TestWithNameTag(t *testing.T) {
+	t.Run("uses value from name tag", func(t *testing.T) {
+		var cfg struct {
+			Val    string `name:"FOO"`
+			Struct struct {
+				Val string `name:"BAR"`
+			}
+		}
+		t.Setenv("FOO", "foo")
+		t.Setenv("STRUCT_BAR", "bar")
+		err := Load(&cfg, WithNameTag("name"))
+		assert.NoError(t, err)
+
+		assert.Equal(t, "foo", cfg.Val)
+		assert.Equal(t, "bar", cfg.Struct.Val)
+	})
+
+	t.Run("uses value from name tag and prefix", func(t *testing.T) {
+		var cfg struct {
+			Val    string `name:"FOO"`
+			Struct struct {
+				Val string `name:"BAR"`
+			}
+		}
+		t.Setenv("PREFIX_FOO", "foo")
+		t.Setenv("PREFIX_STRUCT_BAR", "bar")
+		defer os.Clearenv()
+
+		err := Load(&cfg, WithNameTag("name"), WithPrefix("PREFIX"))
+		assert.NoError(t, err)
+
+		assert.Equal(t, "foo", cfg.Val)
+		assert.Equal(t, "bar", cfg.Struct.Val)
+	})
+
+	t.Run("uses default value", func(t *testing.T) {
+		var cfg struct {
+			Val        string `name:"FOO"`
+			ValDefault string `name:"FOO_DEF" default:"defaultFoo"`
+			Struct     struct {
+				Val        string `name:"BAR"`
+				ValDefault string `name:"FOO_DEF" default:"defaultBar"`
+			}
+		}
+		t.Setenv("FOO", "foo")
+		t.Setenv("STRUCT_BAR", "bar")
+		err := Load(&cfg,
+			WithNameTag("name"),
+			WithDefaultTag("default"),
+		)
+		assert.NoError(t, err)
+
+		assert.Equal(t, "foo", cfg.Val)
+		assert.Equal(t, "bar", cfg.Struct.Val)
+		assert.Equal(t, "defaultFoo", cfg.ValDefault)
+		assert.Equal(t, "defaultBar", cfg.Struct.ValDefault)
+	})
+}
+
+func TestWithEnvTag(t *testing.T) {
+	t.Run("uses value from env tag", func(t *testing.T) {
+		var cfg struct {
+			Val    string `env:"FOO"`
+			Struct struct {
+				Val string `env:"BAR"`
+			}
+		}
+		t.Setenv("FOO", "foo")
+		t.Setenv("BAR", "bar")
+		err := Load(&cfg, WithEnvTag("env"))
+		assert.NoError(t, err)
+
+		assert.Equal(t, "foo", cfg.Val)
+		assert.Equal(t, "bar", cfg.Struct.Val)
+	})
+
+	t.Run("uses value from name tag not the prefix", func(t *testing.T) {
+		var cfg struct {
+			Val    string `env:"FOO"`
+			Struct struct {
+				Val string `env:"BAR"`
+			}
+		}
+		t.Setenv("FOO", "foo")
+		t.Setenv("BAR", "bar")
+		defer os.Clearenv()
+
+		err := Load(&cfg, WithEnvTag("env"), WithPrefix("PREFIX"))
+		assert.NoError(t, err)
+
+		assert.Equal(t, "foo", cfg.Val)
+		assert.Equal(t, "bar", cfg.Struct.Val)
+	})
+
+	t.Run("uses default value", func(t *testing.T) {
+		var cfg struct {
+			Val        string `env:"FOO"`
+			ValDefault string `env:"FOO_DEF" default:"defaultFoo"`
+			Struct     struct {
+				Val        string `env:"BAR"`
+				ValDefault string `env:"FOO_DEF" default:"defaultBar"`
+			}
+		}
+		t.Setenv("FOO", "foo")
+		t.Setenv("BAR", "bar")
+		err := Load(&cfg,
+			WithEnvTag("env"),
+			WithDefaultTag("default"),
+		)
+		assert.NoError(t, err)
+
+		assert.Equal(t, "foo", cfg.Val)
+		assert.Equal(t, "bar", cfg.Struct.Val)
+		assert.Equal(t, "defaultFoo", cfg.ValDefault)
+		assert.Equal(t, "defaultBar", cfg.Struct.ValDefault)
+	})
+
+	t.Run("fails if using on struct", func(t *testing.T) {
+		type Test struct {
+			Val string
+		}
+		var cfg struct {
+			Val    string `env:"FOO"`
+			Struct Test   `env:"SHOULD_FAIL"`
+		}
+		t.Setenv("FOO", "foo")
+		t.Setenv("BAR", "bar")
+		err := Load(&cfg,
+			WithEnvTag("env"),
+			WithDefaultTag("default"),
+		)
+		assert.EqualError(t, err, "failed to load struct { Val string \"env:\\\"FOO\\\"\"; Struct configloader.Test \"env:\\\"SHOULD_FAIL\\\"\" }:\nerror processing field Struct.Val (string): ´env´ tag need to be at the end: [{Struct  configloader.Test env:\"SHOULD_FAIL\" 16 [1] false}]")
+	})
+}
+
+func TestWithDefaultTag(t *testing.T) {
 	t.Run("uses value from default", func(t *testing.T) {
 		var cfg struct {
 			Foo string `default:"foo"`
@@ -185,7 +301,7 @@ func TestWithDefaultTag(t *testing.T) {
 			}
 		}
 
-		err := Load(&cfg, WithEnv(CustomGetenv))
+		err := Load(&cfg)
 		assert.NoError(t, err)
 		assert.Equal(t, "foo", cfg.Foo)
 		assert.Equal(t, "baz", cfg.Bar.Baz)
@@ -199,7 +315,7 @@ func TestWithDefaultTag(t *testing.T) {
 			}
 		}
 
-		err := Load(&cfg, WithDefaultTag("default2"), WithEnv(CustomGetenv))
+		err := Load(&cfg, WithDefaultTag("default2"))
 		assert.NoError(t, err)
 		assert.Equal(t, "foo", cfg.Foo)
 		assert.Equal(t, "baz", cfg.Bar.Baz)
@@ -215,10 +331,10 @@ func TestWithDefaultTag(t *testing.T) {
 			}
 		}
 
-		require.NoError(t, os.Setenv("FOO", "fooEnv"))
-		require.NoError(t, os.Setenv("BAR_BAZ", "bazEnv"))
+		t.Setenv("FOO", "fooEnv")
+		t.Setenv("BAR_BAZ", "bazEnv")
 
-		err := Load(&cfg, WithEnv(CustomGetenv))
+		err := Load(&cfg)
 		assert.NoError(t, err)
 		assert.Equal(t, "fooEnv", cfg.Foo)
 		assert.Equal(t, "bazEnv", cfg.Bar.Baz)
@@ -232,7 +348,7 @@ func TestWithDefaultTag(t *testing.T) {
 			}
 		}
 
-		err := Load(&cfg, WithEnv(CustomGetenv))
+		err := Load(&cfg)
 		assert.NoError(t, err)
 
 		foo, err := url.Parse("https://example.com/foo")
@@ -245,55 +361,115 @@ func TestWithDefaultTag(t *testing.T) {
 	})
 }
 
-func TestLoadingWithPointerNested(t *testing.T) {
-	type SecondElement struct {
-		Url string
-	}
+func TestWithTypeHandler(t *testing.T) {
+	t.Run("fails with unsupported types", func(t *testing.T) {
+		type CustomType string
+		var cfg struct {
+			Val CustomType
+		}
+		t.Setenv("VAL", "foo")
+		defer os.Clearenv()
+		err := Load(&cfg)
+		assert.EqualError(t, err,
+			`failed to load struct { Val configloader.CustomType }:
+error processing field Val (configloader.CustomType): unsupported type configloader.CustomType`)
+	})
 
-	type PointerElement struct {
-		Name string
-		Sec  *SecondElement
-	}
+	t.Run("fails with error from handler", func(t *testing.T) {
+		type CustomType string
+		var cfg struct {
+			Val CustomType
+		}
+		t.Setenv("VAL", "foo")
+		defer os.Clearenv()
 
-	type ConfigWP struct {
-		Pel *PointerElement
-	}
+		expectedErr := errors.New("expected")
+		err := Load(&cfg, WithTypeHandler(func(val string) (CustomType, error) {
+			assert.Equal(t, "foo", val)
+			return "", expectedErr
+		}))
+		assert.ErrorIs(t, err, expectedErr)
+		assert.EqualError(t, err, `failed to load struct { Val configloader.CustomType }:
+error processing field Val (configloader.CustomType): expected`)
+	})
 
-	// NOTE: This is how we use the lib.
-	t.Setenv("PEL_NAME", "alfredo")
-	t.Setenv("PEL_SEC_URL", "www.pelsec.url")
-	var conf ConfigWP
-	err := Load(&conf)
+	t.Run("fails with element of slice", func(t *testing.T) {
+		type CustomType string
+		var cfg struct {
+			Val []CustomType
+		}
+		t.Setenv("VAL", "foo,foo")
+		defer os.Clearenv()
 
-	assert.NoError(t, err, "Expected error free Load")
-	assert.Equal(t, "alfredo", conf.Pel.Name)
-	assert.Equal(t, "www.pelsec.url", conf.Pel.Sec.Url)
+		expectedErr := errors.New("expected")
+		err := Load(&cfg, WithTypeHandler(func(val string) (CustomType, error) {
+			assert.Equal(t, "foo", val)
+			return "", expectedErr
+		}))
+		assert.ErrorIs(t, err, expectedErr)
+		assert.EqualError(t, err, "failed to load struct { Val []configloader.CustomType }:\nerror processing field Val ([]configloader.CustomType): expected\nexpected")
+	})
+
+	t.Run("support custom handler for primitive", func(t *testing.T) {
+		type AnotherString string
+		var cfg struct {
+			Val      AnotherString
+			ValPtr   *AnotherString
+			ValSlice []AnotherString
+		}
+		t.Setenv("VAL", "foo")
+		t.Setenv("VAL_PTR", "foo")
+		t.Setenv("VAL_SLICE", "foo,foo")
+		defer os.Clearenv()
+
+		err := Load(&cfg, WithTypeHandler(func(val string) (AnotherString, error) {
+			assert.Equal(t, "foo", val)
+			return "notFoo", nil
+		}))
+		assert.NoError(t, err)
+
+		assert.Equal(t, AnotherString("notFoo"), cfg.Val)
+		assert.Equal(t, AnotherString("notFoo"), *cfg.ValPtr)
+		assert.Equal(t, []AnotherString{"notFoo", "notFoo"}, cfg.ValSlice)
+	})
+
+	t.Run("support custom handler for structs", func(t *testing.T) {
+		type Test struct {
+			Val string
+		}
+		var cfg struct {
+			Val      Test
+			ValPtr   *Test
+			ValSlice []Test
+		}
+		t.Setenv("VAL", "foo")
+		t.Setenv("VAL_PTR", "foo")
+		t.Setenv("VAL_SLICE", "foo,foo")
+		defer os.Clearenv()
+
+		err := Load(&cfg, WithTypeHandler(func(val string) (Test, error) {
+			assert.Equal(t, "foo", val)
+			return Test{Val: "notFoo"}, nil
+		}))
+		assert.NoError(t, err)
+
+		assert.Equal(t, Test{Val: "notFoo"}, cfg.Val)
+		assert.Equal(t, Test{Val: "notFoo"}, *cfg.ValPtr)
+		assert.Equal(t, []Test{{Val: "notFoo"}, {Val: "notFoo"}}, cfg.ValSlice)
+	})
 }
 
-func TestLoadingComplexType(t *testing.T) {
-	// Complex types
-	type ComplexTypeEx struct {
-		Timeout time.Duration
-		URL     url.URL
-		IPAddr  net.IP
-	}
+func TestWithEnv(t *testing.T) {
+	t.Run("support custom env", func(t *testing.T) {
+		var cfg struct {
+			Val string
+		}
 
-	t.Setenv("TIMEOUT", "1s")
-	t.Setenv("URL_HOST", "localhost:8080")
-	t.Setenv("IP_ADDR", "192.168.1.1")
-
-	var conf ComplexTypeEx
-	err := Load(&conf,
-		WithTypeHandler[time.Duration](func(s string) (time.Duration, error) {
-			return time.ParseDuration(s)
-		}), // IP address handler
-		WithTypeHandler[net.IP](func(s string) (net.IP, error) {
-			return net.ParseIP(s), nil
+		err := Load(&cfg, WithEnv(func(s string) (string, bool) {
+			assert.Equal(t, "VAL", s)
+			return "notFoo", true
 		}))
-
-	assert.NoError(t, err, "Expected error free Load")
-	sec, _ := time.ParseDuration("1s")
-	assert.Equal(t, sec, conf.Timeout, "Timeout was not read properly")
-	assert.Equal(t, "localhost:8080", conf.URL.Host)
-	assert.Equal(t, "192.168.1.1", conf.IPAddr.String())
+		require.NoError(t, err)
+		assert.Equal(t, "notFoo", cfg.Val)
+	})
 }

--- a/configloader/errors.go
+++ b/configloader/errors.go
@@ -1,0 +1,64 @@
+package configloader
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// ConfigLoadError represents the errors that occurred during config loading.
+type ConfigLoadError struct {
+	Value  reflect.Type
+	Errors []error
+}
+
+func (e *ConfigLoadError) Add(err error) {
+	if err != nil {
+		e.Errors = append(e.Errors, err)
+	}
+}
+
+func (e *ConfigLoadError) Error() string {
+	var msgs = make([]string, len(e.Errors))
+	for i, err := range e.Errors {
+		msgs[i] = err.Error()
+	}
+	return fmt.Sprintf("failed to load %s:\n%s", e.Value.String(),
+		strings.Join(msgs, "\n"))
+}
+
+func (e *ConfigLoadError) Unwrap() []error {
+	return e.Errors
+}
+
+// FieldError represents an error that occurred while processing a specific field.
+type FieldError struct {
+	Field
+	Err error
+}
+
+func (e FieldError) Error() string {
+	return fmt.Sprintf("error processing field %s: %v", e.Field.String(), e.Err)
+}
+
+func (e FieldError) Unwrap() error {
+	return e.Err
+}
+
+// MissingEnvError represents an error when a required environment variable is not found.
+type MissingEnvError struct {
+	Key string
+}
+
+func (e MissingEnvError) Error() string {
+	return fmt.Sprintf("environment variable %s not found", e.Key)
+}
+
+// UnsupportedTypeError represents an error when trying to process a field with an unsupported type.
+type UnsupportedTypeError struct {
+	Type reflect.Type
+}
+
+func (e UnsupportedTypeError) Error() string {
+	return fmt.Sprintf("unsupported type %v", e.Type)
+}

--- a/configloader/go.mod
+++ b/configloader/go.mod
@@ -3,9 +3,14 @@ module github.com/coopnorge/member-lib/configloader
 go 1.23.0
 
 require (
+	fortio.org/safecast v1.0.0
+	github.com/ccoveille/go-safecast v1.2.0
+	github.com/iancoleman/strcase v0.3.0
+	github.com/stretchr/testify v1.9.0
+)
+
+require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/iancoleman/strcase v0.3.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.9.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/configloader/go.sum
+++ b/configloader/go.sum
@@ -1,3 +1,7 @@
+fortio.org/safecast v1.0.0 h1:dr3131WPX8iS1pTf76+39WeXbTrerDYLvi9s7Oi3wiY=
+fortio.org/safecast v1.0.0/go.mod h1:xZmcPk3vi4kuUFf+tq4SvnlVdwViqf6ZSZl91Jr9Jdg=
+github.com/ccoveille/go-safecast v1.2.0 h1:H4X7aosepsU1Mfk+098CTdKpsDH0cfYJ2RmwXFjgvfc=
+github.com/ccoveille/go-safecast v1.2.0/go.mod h1:QqwNjxQ7DAqY0C721OIO9InMk9zCwcsO7tnRuHytad8=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/iancoleman/strcase v0.3.0 h1:nTXanmYxhfFAMjZL34Ov6gkzEsSJZ5DbhxWjvSASxEI=
@@ -6,6 +10,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/configloader/options.go
+++ b/configloader/options.go
@@ -1,0 +1,121 @@
+package configloader
+
+import "reflect"
+
+type Option func(*Loader)
+
+// WithTypeHandler registers a custom type conversion function for a specific type T.
+// The function should convert a string environment value to type T, returning an error
+// if the conversion fails.
+//
+// Example:
+//
+//	configloader.Load(&cfg, WithTypeHandler(func(s string) (time.Duration, error) {
+//	    return time.ParseDuration(s)
+//	}))
+func WithTypeHandler[T any](f func(string) (T, error)) Option {
+	return func(l *Loader) {
+		var zero T
+		l.handlers[reflect.TypeOf(zero)] = func(value string) (any, error) {
+			return f(value)
+		}
+	}
+}
+
+// WithNameTag sets the struct tag used to override a field's name in the environment variable path.
+// The tag value replaces just the field's name segment while still following the normal path construction
+// rules (prefix + path + name).
+//
+// Example with WithNameTag("name"):
+//
+//	type Config struct {
+//	    Database struct {
+//	        Host string `name:"HOSTNAME"` // Looks for DATABASE_HOSTNAME
+//	    }
+//	}
+//	configloader.Load(&cfg)
+//
+// Example with both prefix and name tag:
+//
+//	type Config struct {
+//	    Database struct {
+//	        Host string `name:"HOSTNAME"` // Looks for APP_DATABASE_HOSTNAME
+//	    }
+//	}
+//	configloader.Load(&cfg, WithPrefix("APP"))
+func WithNameTag(tag string) Option {
+	return func(l *Loader) {
+		l.nameTag = tag
+	}
+}
+
+// WithEnvTag sets the struct tag used to completely override the environment variable name for a field.
+// When a field has this tag, its value is used as-is for the environment variable name, bypassing all
+// other name construction rules including prefixes and path building.
+//
+// Example with WithEnvTag("env"):
+//
+//	type Config struct {
+//	    Database struct {
+//	        // Despite nesting, looks directly for "DB_HOST"
+//	        Host string `env:"DB_HOST"`
+//	    }
+//	}
+//	configloader.Load(&cfg)
+//
+// Example showing prefix is ignored with env tag:
+//
+//	type Config struct {
+//	    Database struct {
+//	        // Still only looks for "DB_HOST", prefix is not applied
+//	        Host string `env:"DB_HOST"`
+//	    }
+//	}
+//	configloader.Load(&cfg, WithPrefix("APP"))
+func WithEnvTag(tag string) Option {
+	return func(l *Loader) {
+		l.envTag = tag
+	}
+}
+
+// WithDefaultTag sets the struct tag used for specifying default values.
+// If an environment variable is not found, the value of this tag will be used instead.
+//
+// Example:
+//
+//	type Config struct {
+//	    Port int `default:"8080"`  // Will use 8080 if PORT is not set
+//	}
+//	configloader.Load(&cfg, WithDefaultTag("default"))
+func WithDefaultTag(tag string) Option {
+	return func(l *Loader) {
+		l.defaultTag = tag
+	}
+}
+
+// WithPrefix sets a prefix that will be prepended to all environment variable names.
+// The prefix and field name will be joined with an underscore.
+//
+// Example:
+//
+//	type Config struct {
+//	    Port int  // Will look for "APP_PORT" environment variable
+//	}
+//	configloader.Load(&cfg, WithPrefix("APP"))
+func WithPrefix(prefix string) Option {
+	return func(l *Loader) {
+		l.prefix = prefix
+	}
+}
+
+// WithEnv sets a custom function for looking up environment variables.
+// This is primarily useful for testing or when environment variables need to be
+// sourced from somewhere other than os.LookupEnv.
+//
+// The function should return the value and a boolean indicating whether the variable
+// was found, similar to os.LookupEnv.
+func WithEnv(env func(string) (string, bool)) Option {
+	return func(l *Loader) {
+		l.env = env
+	}
+}

--- a/configloader/types.go
+++ b/configloader/types.go
@@ -8,7 +8,10 @@ import (
 	"net"
 	"net/url"
 	"regexp"
+	"strconv"
 	"time"
+
+	"fortio.org/safecast"
 )
 
 var defaultTypeHandlers = []Option{
@@ -47,4 +50,54 @@ var defaultTypeHandlers = []Option{
 		_, network, err := net.ParseCIDR(val)
 		return network, err
 	}),
+
+	WithTypeHandler(parseInt(safecast.Convert[int64])),
+	WithTypeHandler(parseInt(safecast.Convert[int32])),
+	WithTypeHandler(parseInt(safecast.Convert[int16])),
+	WithTypeHandler(parseInt(safecast.Convert[int8])),
+	WithTypeHandler(parseInt(safecast.Convert[int])),
+
+	WithTypeHandler(parseUint(safecast.Convert[uint64])),
+	WithTypeHandler(parseUint(safecast.Convert[uint32])),
+	WithTypeHandler(parseUint(safecast.Convert[uint16])),
+	WithTypeHandler(parseUint(safecast.Convert[uint8])),
+	WithTypeHandler(parseUint(safecast.Convert[uint])),
+
+	WithTypeHandler(parseFloat(safecast.Convert[float64])),
+	WithTypeHandler(parseFloat(safecast.Convert[float32])),
+
+	WithTypeHandler(strconv.ParseBool),
+	WithTypeHandler(func(val string) (string, error) {
+		return val, nil
+	}),
+}
+
+func parseInt[T any](cast func(int64) (T, error)) func(string) (T, error) {
+	return func(val string) (res T, err error) {
+		parsed, err := strconv.ParseInt(val, 10, 64)
+		if err != nil {
+			return res, err
+		}
+		return cast(parsed)
+	}
+}
+
+func parseUint[T any](cast func(uint64) (T, error)) func(string) (T, error) {
+	return func(val string) (res T, err error) {
+		parsed, err := strconv.ParseUint(val, 10, 64)
+		if err != nil {
+			return res, err
+		}
+		return cast(parsed)
+	}
+}
+
+func parseFloat[T any](cast func(float64) (T, error)) func(string) (T, error) {
+	return func(val string) (res T, err error) {
+		parsed, err := strconv.ParseFloat(val, 64)
+		if err != nil {
+			return res, err
+		}
+		return cast(parsed)
+	}
 }


### PR DESCRIPTION
This PR adds support for a default tag value that can be used if the value is not found.

```go
	t.Run("uses value from default", func(t *testing.T) {
		var cfg struct {
			Foo string `default:"foo"`
			Bar struct {
				Baz string `default:"baz"`
			}
		}

		err := Load(&cfg, WithEnv(CustomGetenv))
		assert.NoError(t, err)
		assert.Equal(t, "foo", cfg.Foo)
		assert.Equal(t, "baz", cfg.Bar.Baz)
	})
```