### PR TITLE
chore(deps): update Go directive to 1.26.0

### DIFF
--- a/.github/workflows/golang-ci.yaml
+++ b/.github/workflows/golang-ci.yaml
@@ -28,11 +28,11 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.26"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
         with:
-          version: v2.7
+          version: v2.11
           working-directory: ${{ matrix.path }}
           args: -v ./...
 
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.26"
       - name: Run tests with coverage
         run: |
           cd ${{ matrix.path }}

--- a/configloader/go.mod
+++ b/configloader/go.mod
@@ -1,6 +1,6 @@
 module github.com/coopnorge/member-lib/configloader
 
-go 1.25.0
+go 1.26.0
 
 require (
 	fortio.org/safecast v1.2.0

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -1,6 +1,6 @@
 module github.com/coopnorge/member-lib/pkg
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/google/uuid v1.6.0

--- a/telemetry/go.mod
+++ b/telemetry/go.mod
@@ -1,6 +1,6 @@
 module github.com/coopnorge/member-lib/telemetry
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/DataDog/datadog-go/v5 v5.5.0


### PR DESCRIPTION
Go 1.24 is no longer supported. Update the Go directive to 1.26.0
to comply with the Coop Norge Go language guidelines requiring use
of a supported Go release.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
